### PR TITLE
[PR] Refactor pagination link logic to skip over empty days

### DIFF
--- a/includes/archives.php
+++ b/includes/archives.php
@@ -205,6 +205,7 @@ function filter_page_title( $title, $site_part, $global_part ) {
  * Generate the URLs used to view previous and next date archives.
  *
  * @since 0.2.0
+ * @since 0.3.0 Refactored to skip over empty views.
  *
  * @return array
  */

--- a/includes/archives.php
+++ b/includes/archives.php
@@ -263,8 +263,17 @@ function get_pagination_urls() {
 		$previous_url = $base_url . $path;
 	}
 
-	// Build out the next link URL and label.
-	if ( is_day() || is_post_type_archive( 'event' ) ) {
+	/**
+	 * Build out the next link URL and label.
+	 *
+	 * Paging forward is available for, in order of appearance in the condition:
+	 *   1) the `event` post type archive view;
+	 *   2) day archive views;
+	 *   3) taxonomy views that are also day archive views.
+	 *
+	 * ("Normal" taxonomy archive views display all upcoming events already).
+	 */
+	if ( is_post_type_archive( 'event' ) || is_day() || ( ! is_tax() || ( is_tax() && is_day() ) ) ) {
 
 		// Adjust query arguments to find the next adjacent event.
 		$next_day = date( 'Y-m-d 00:00:00', strtotime( $current_view_date . ' + 1 days' ) );
@@ -294,6 +303,9 @@ function get_pagination_urls() {
 				$next_url = $base_url . $path;
 				$next_label = ( $next_day > date( 'Y-m-d 00:00:00' ) ) ? 'Upcoming events' : 'Next events';
 			}
+		} elseif ( is_tax() && is_day() ) {
+			$next_url = $base_url;
+			$next_label = 'Upcoming events';
 		}
 	}
 

--- a/includes/archives.php
+++ b/includes/archives.php
@@ -209,6 +209,8 @@ function filter_page_title( $title, $site_part, $global_part ) {
  * @return array
  */
 function get_pagination_urls() {
+	date_default_timezone_set( 'America/Los_Angeles' );
+
 	$current_view_date = date( 'Y-m-d 00:00:00' );
 	$base_url = get_post_type_archive_link( 'event' );
 	$previous_url = false;
@@ -263,6 +265,7 @@ function get_pagination_urls() {
 
 	// Build out the next link URL and label.
 	if ( is_day() || is_post_type_archive( 'event' ) ) {
+
 		// Adjust query arguments to find the next adjacent event.
 		$next_day = date( 'Y-m-d 00:00:00', strtotime( $current_view_date . ' + 1 days' ) );
 		$adjacent_event_query_args['order'] = 'ASC';
@@ -278,8 +281,16 @@ function get_pagination_urls() {
 				$next_url = $base_url;
 				$next_label = ( is_tax() ) ? 'Upcoming events' : 'Today’s events';
 			} else {
-				$start_date = get_post_meta( $next_event[0], 'wp_event_calendar_date_time', true );
-				$path = date( 'Y/m/d/', strtotime( $start_date ) );
+				$start_date = get_post_meta( $next_event[0], 'wp_event_calendar_date_time' );
+
+				foreach ( $start_date as $start ) {
+					if ( $start === $current_view_date ) {
+						continue;
+					}
+
+					$path = date( 'Y/m/d/', strtotime( $start ) );
+				}
+
 				$next_url = $base_url . $path;
 				$next_label = ( $next_day > date( 'Y-m-d 00:00:00' ) ) ? 'Upcoming events' : 'Next events';
 			}

--- a/includes/archives.php
+++ b/includes/archives.php
@@ -298,6 +298,8 @@ function get_pagination_urls() {
 					}
 
 					$path = date( 'Y/m/d/', strtotime( $start ) );
+
+					break;
 				}
 
 				$next_url = $base_url . $path;


### PR DESCRIPTION
This still allows for "top level" archive views with no events listed - that is, the event post type archive view (currently at `/event/`) and the taxonomy term archive views.